### PR TITLE
fix: illegal instruction error in Creature.cpp:3470

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -3469,6 +3469,8 @@ bool Creature::SetCannotReachTarget(bool cannotReach, bool isChase /*= true*/)
 
     if (cannotReach)
         LOG_DEBUG("entities.unit", "Creature::SetCannotReachTarget() called with true. Details: {}", GetDebugInfo());
+
+    return true;
 }
 
 time_t Creature::GetLastDamagedTime() const


### PR DESCRIPTION
## Changes Proposed:
add a return statement at the end of Creature::SetCannotReachTarget. 

## Tests Performed:
Tested on ubuntu server 18.04

## How to Test the Changes:
If this return statement is omitted, at a random time during execution, the worldserver will crash and throw an Illegal Instruction error.
