### PR TITLE
fix-db_import-error on docker start:app 

### DIFF
--- a/apps/compiler/includes/functions.sh
+++ b/apps/compiler/includes/functions.sh
@@ -208,9 +208,9 @@ function conf_layer() {
         if grep -qE "^$KEY" "$BASE" && ! grep -qE "^$KEY.*=.*$VAL" "$BASE"; then
           # Replace line
           # Prevent issues with shell quoting 
-          sed -i \
-            's,^'"$KEY"'.*,'"$KEY = $VAL$COMMENT"',g' \
-            "$BASE"
+          # prevents failures on docker build due to permissions creating config files
+          sed 's,^'"$KEY"'.*,'"$KEY = $VAL$COMMENT"',g' "$BASE" > tmp; cat tmp > "$BASE"; rm tmp
+
         else
           # insert line
           echo "$KEY = $VAL$COMMENT" >> "$BASE"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -203,6 +203,7 @@ services:
       - ${DOCKER_VOL_DATA_MAPS:-./env/docker/data/maps}:/azerothcore/env/dist/data/maps
       - ${DOCKER_VOL_DATA_VMAPS:-./env/docker/data/vmaps}:/azerothcore/env/dist/data/vmaps
       - ${DOCKER_VOL_DATA_MMAPS:-./env/docker/data/mmaps}:/azerothcore/env/dist/data/mmaps
+      - /Users/bcarter/WoW/playerbots/azerothcore-wotlk/modules:/azerothcore/modules
     profiles: [local, app, worldserver]
     depends_on:
       ac-database:


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Updated docker-compose.yml to mount modules folder, was breaking certain modules on docker builds
-  Updated config sed in function.h was causing permissions error when doing inline replacement

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
-  Tested on Mac OSX Ventura - Apple Silicon
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Ran ./acore.sh docker build && ./acore.sh docker start:app
2. Started Game and played for a long time
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
